### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
+++ b/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
@@ -52,7 +52,12 @@ function createSimpleDevServer(rendererOut: string): http.Server {
     .createServer(async (req, res) => {
       const url = req.url || '';
       const file = url.endsWith('main_window') ? path.join(url, '/index.html') : url;
-      const fullPath = path.join(rendererOut, file);
+      const fullPath = path.resolve(rendererOut, file);
+      if (!fullPath.startsWith(rendererOut)) {
+        res.writeHead(403);
+        res.end('Forbidden');
+        return;
+      }
       try {
         const data = await readFile(fullPath);
         res.writeHead(200);


### PR DESCRIPTION
Fixes [https://github.com/HyperCogWizard/electron-forge/security/code-scanning/1](https://github.com/HyperCogWizard/electron-forge/security/code-scanning/1)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root directory. This can be achieved by normalizing the path using `path.resolve` and then verifying that the normalized path starts with the root directory. If the path is not within the root directory, we should return a 403 Forbidden response.

1. Normalize the `fullPath` using `path.resolve` to remove any ".." segments.
2. Verify that the normalized path starts with the `rendererOut` directory.
3. If the path is not within the `rendererOut` directory, return a 403 Forbidden response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
