### PR TITLE
Fix code scanning alert no. 2: Information exposure through a stack trace

### DIFF
--- a/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
+++ b/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
@@ -63,8 +63,9 @@ function createSimpleDevServer(rendererOut: string): http.Server {
         res.writeHead(200);
         res.end(data);
       } catch (err) {
-        res.writeHead(404);
-        res.end(JSON.stringify(err));
+        console.error("Error reading file:", err); // Log the error on the server
+        res.writeHead(500);
+        res.end("An error occurred while processing your request."); // Send a generic error message to the client
       }
     })
     .listen(3000);


### PR DESCRIPTION
Fixes [https://github.com/HyperCogWizard/electron-forge/security/code-scanning/2](https://github.com/HyperCogWizard/electron-forge/security/code-scanning/2)

To fix the problem, we need to ensure that the stack trace and other sensitive information are not exposed to the client. Instead, we should log the error on the server and send a generic error message to the client. This can be achieved by modifying the catch block to log the error and send a generic message.

- Modify the catch block in the `createSimpleDevServer` function to log the error and send a generic error message.
- Ensure that the logging mechanism is in place to capture the error details for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
